### PR TITLE
update container to debian 13 and install missing e2fsprogs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM debian:9.13
+FROM debian:13
 
+RUN apt-get update && apt-get install -y e2fsprogs && apt-get clean all
 COPY ./bin/nvmfplugin .
 
 ENTRYPOINT ["/nvmfplugin"]


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Update base of the image to debian 13 (as the 9.13 has issues installing anything from repos anymore) and install missing e2fsprogs that are needed for default ext4 fs that is created autmatically when mounting empty disk

**Which issue(s) this PR fixes**:
Not reported yet

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
none
```